### PR TITLE
[#6] feat: 댓글 추가, 삭제 구현

### DIFF
--- a/src/api/PostService.ts
+++ b/src/api/PostService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { apiService } from '.';
-import { Post } from '../types/Post';
+import { CommentType, Post } from '../types/Post';
 
 interface FetchPostListResponse {
   code: number;
@@ -12,8 +12,8 @@ interface FetchPostListResponse {
 interface FetchPostDetailResponse {
   code: number;
   data: {
-    post: Post[];
-    comments: any;
+    post: Post;
+    comments: CommentType[];
   };
 }
 
@@ -84,5 +84,19 @@ export namespace PostService {
    */
   export async function deletePost(postId: string) {
     return apiService._delete(`/post/${postId}`).then(v => v.data);
+  }
+
+  /**
+   * 댓글을 생성합니다.
+   */
+  export async function createComment(postId: string, content: string) {
+    return apiService.post(`/comment/${postId}`, { content });
+  }
+
+  /**
+   * 댓글을 삭제합니다.
+   */
+  export async function deleteComment(commentId: string) {
+    return apiService._delete(`/comment/${commentId}`);
   }
 }

--- a/src/css/postDetail.css
+++ b/src/css/postDetail.css
@@ -1,3 +1,8 @@
+.PostDetailPage {
+  display: flex;
+  flex-direction: column;
+}
+
 .title__container {
   display: flex;
   justify-content: space-between;
@@ -51,4 +56,49 @@
   border-radius: 1rem;
   padding: 1rem 0;
   margin: 2rem;
+}
+
+.comment-form {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 2rem;
+}
+
+.comment-input {
+  display: flex;
+  flex-grow: 1;
+  border: 2px solid black;
+  font-size: 2rem;
+}
+
+.comment-submit-btn {
+  display: flex;
+  flex-shrink: 1;
+  font-size: 1.4rem;
+  align-items: center;
+  justify-content: center;
+  background-color: black;
+  color: white;
+  border-radius: 1rem;
+  padding: 1.2rem;
+  margin-left: 0.5rem;
+}
+
+.comment-section {
+  padding: 2rem;
+}
+
+.comment-title {
+  font-size: 2rem;
+}
+
+.comment-item {
+  border: 1px solid black;
+  padding: 1rem;
+  font-size: 2rem;
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
 }

--- a/src/pages/PostDetailPage.ts
+++ b/src/pages/PostDetailPage.ts
@@ -1,12 +1,17 @@
 import { PostService } from '../api/PostService';
 import { PostDetail } from '../components/PostDetail';
-import { Post } from '../types/Post';
+import { CommentType, Post } from '../types/Post';
 import '../css/postDetail.css';
 import { goBack } from '../router';
 
+interface Data {
+  post: Post;
+  comments: CommentType[];
+}
+
 interface IPostDetailPage {
-  state: Post;
-  setState: (value: Post) => void;
+  state: Data;
+  setState: (value: Data) => void;
   render: () => void;
 }
 
@@ -51,7 +56,7 @@ export const PostDetailPage = function (
 
   const fetchPostDetail = async () => {
     const result = await PostService.fetchPost(postID);
-    this.setState({ ...this.state, ...result.data.post });
+    this.setState({ ...this.state, ...result.data });
   };
 
   fetchPostDetail();

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -6,3 +6,9 @@ export type Post = {
   createdAt: string; // "2023-01-13T18:42:00.453Z"
   updatedAt: string;
 };
+
+export type CommentType = {
+  commentId: string;
+  postId: string;
+  content: string;
+};


### PR DESCRIPTION
- 댓글 생성, 삭제 api 연동
- 글 상세 페이지에 코멘트 렌더링 부분 추가

## 스크린샷
![댓글추가삭제](https://user-images.githubusercontent.com/41099712/212935905-9dde907b-8c14-4a75-871a-554c41e5182b.gif)
